### PR TITLE
Fixed broken scilifelab link

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: base
 ---
 # Clinical Genomics 
- Clinical Genomics är en facilitet under [SciLifeLab](www.scilifelab.se)
+ Clinical Genomics är en facilitet under [SciLifeLab](http://www.scilifelab.se)
 
 ## Nyheter
 **Ny hemsida!**


### PR DESCRIPTION
The link on the homepage needs the `http`, currently it tries to go to `http://www.clinicalgenomics.se/www.scilifelab.se` and breaks :grinning: 